### PR TITLE
Update the linter to WordPress coding standards

### DIFF
--- a/code-climate-rule-sets/.sass-lint-r-1.x.yml
+++ b/code-climate-rule-sets/.sass-lint-r-1.x.yml
@@ -1,0 +1,99 @@
+files:
+  include: '**/*.s+(a|c)ss'
+  ignore:
+rules:
+  # Not allowed at all
+  border:
+    - 2
+    - convention: 'none'
+  brace-style:
+    - 2
+    - allow-single-line: false
+  clean-import-paths: 2
+  empty-args: 2
+  empty-line-between-blocks:
+    - 2
+    - allow-single-line-rulesets: false
+  extends-before-declarations: 2
+  extends-before-mixins: 2
+  force-element-nesting: 2
+  force-pseudo-nesting: 2
+  hex-length: 2
+  hex-notation: 2
+  leading-zero:
+    - 2
+    - true
+  mixins-before-declarations: 2
+  no-empty-rulesets: 2
+  no-color-keywords: 2
+  placeholder-in-extend: 2
+  one-declaration-per-line: 2
+  single-line-per-selector: 2
+  nesting-depth: 2
+  no-invalid-hex: 2
+  no-misspelled-properties: 2
+  no-qualifying-elements:
+    - 2
+    - allow-element-with-attribute: true
+  no-trailing-whitespace: 2
+  no-trailing-zero: 2
+  no-transition-all: 2
+  no-url-protocols: 2
+  quotes:
+    - 2
+    - style: double
+  shorthand-values: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang: 2
+  space-before-brace: 2
+  space-before-colon: 2
+  space-between-parens: 2
+  trailing-semicolon: 2
+  url-quotes: 2
+  zero-unit: 2
+  class-name-format:
+    - 2
+    -
+      convention: (?!^col-)^[a-z][a-zA-Z0-9-?]*$
+      convention-explanation: 'Classes may not use UPPERCASE or underscores. Additonally, overriding the col- classes is prohibited.'
+      allow-leading-underscore: false
+  placeholder-name-format:
+    - 2
+    -
+      convention:  (?!^col-)^[a-z][a-zA-Z0-9-?]*$
+      convention-explanation: 'Please use camelCase and hyphenation for your placeholder naming.'
+      allow-leading-underscore: false
+  variable-name-format:
+    - 0
+    -
+      convention:  (^[a-z][a-zA\--Z0-9]*$)
+      convention-explanation: 'Please use camelCase and hyphenation for your variable naming.'
+      allow-leading-underscore: false
+  id-name-format:
+    - 0
+    -
+      convention:  (^[a-z][a-zA\--Z0-9]*$)
+      convention-explanation: 'Please use camelCase and hyphenation for your ID naming.'
+      allow-leading-underscore: false
+
+  # Just a warning
+  no-duplicate-properties:
+    - 1
+    - exclude:
+      - display
+  no-important: 1
+  no-mergeable-selectors: 1
+  no-vendor-prefixes: 1
+  no-color-literals: 1
+  # name-format: 0
+  # property-sort-order: 1
+  # property-spelling: 0
+  # shorthand: 0
+
+  # Stuff we don't care about
+  no-css-comments: 0
+  final-newline: 0
+  no-ids: 0
+  indentation: 0

--- a/code-climate-rule-sets/.sass-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.sass-lint-r-2.x.yml
@@ -1,4 +1,3 @@
-# The current coding standards. Any changes made to this file should be reflected in .sass-lint-r-2.x.yml as well.
 # A slightly stricter linter based on WordPress Coding Standards.
 
 scss_files: "**/*.scss"

--- a/code-climate-rule-sets/.sass-lint.yml
+++ b/code-climate-rule-sets/.sass-lint.yml
@@ -1,99 +1,223 @@
-files:
-  include: '**/*.s+(a|c)ss'
-  ignore:
-rules:
-  # Not allowed at all
-  border:
-    - 2
-    - convention: 'none'
-  brace-style:
-    - 2
-    - allow-single-line: false
-  clean-import-paths: 2
-  empty-args: 2
-  empty-line-between-blocks:
-    - 2
-    - allow-single-line-rulesets: false
-  extends-before-declarations: 2
-  extends-before-mixins: 2
-  force-element-nesting: 2
-  force-pseudo-nesting: 2
-  hex-length: 2
-  hex-notation: 2
-  leading-zero:
-    - 2
-    - true
-  mixins-before-declarations: 2
-  no-empty-rulesets: 2
-  no-color-keywords: 2
-  placeholder-in-extend: 2
-  one-declaration-per-line: 2
-  single-line-per-selector: 2
-  nesting-depth: 2
-  no-invalid-hex: 2
-  no-misspelled-properties: 2
-  no-qualifying-elements:
-    - 2
-    - allow-element-with-attribute: true
-  no-trailing-whitespace: 2
-  no-trailing-zero: 2
-  no-transition-all: 2
-  no-url-protocols: 2
-  quotes:
-    - 2
-    - style: double
-  shorthand-values: 2
-  space-after-colon: 2
-  space-after-comma: 2
-  space-around-operator: 2
-  space-before-bang: 2
-  space-before-brace: 2
-  space-before-colon: 2
-  space-between-parens: 2
-  trailing-semicolon: 2
-  url-quotes: 2
-  zero-unit: 2
-  class-name-format:
-    - 2
-    -
-      convention: (?!^col-)^[a-z][a-zA-Z0-9-?]*$
-      convention-explanation: 'Classes may not use UPPERCASE or underscores. Additonally, overriding the col- classes is prohibited.'
-      allow-leading-underscore: false
-  placeholder-name-format:
-    - 2
-    -
-      convention:  (?!^col-)^[a-z][a-zA-Z0-9-?]*$
-      convention-explanation: 'Please use camelCase and hyphenation for your placeholder naming.'
-      allow-leading-underscore: false
-  variable-name-format:
-    - 0
-    -
-      convention:  (^[a-z][a-zA\--Z0-9]*$)
-      convention-explanation: 'Please use camelCase and hyphenation for your variable naming.'
-      allow-leading-underscore: false
-  id-name-format:
-    - 0
-    -
-      convention:  (^[a-z][a-zA\--Z0-9]*$)
-      convention-explanation: 'Please use camelCase and hyphenation for your ID naming.'
-      allow-leading-underscore: false
+# A slightly stricter linter based on WordPress Coding Standards.
 
-  # Just a warning
-  no-duplicate-properties:
-    - 1
-    - exclude:
-      - display
-  no-important: 1
-  no-mergeable-selectors: 1
-  no-vendor-prefixes: 1
-  no-color-literals: 1
-  # name-format: 0
-  # property-sort-order: 1
-  # property-spelling: 0
-  # shorthand: 0
+scss_files: "**/*.scss"
 
-  # Stuff we don't care about
-  no-css-comments: 0
-  final-newline: 0
-  no-ids: 0
-  indentation: 0
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+# TODO: Write a custom linter for the grid. https://github.com/brigade/scss-lint#custom-linters
+# plugin_gems: []
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+    style: silent
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: short
+
+  HexNotation:
+    enabled: true
+    style: lowercase
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: false
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: tab
+    width: 1
+
+  LeadingZero:
+    enabled: true
+    style: include_zero
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase
+
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: true
+
+  PrivateNamingConvention:
+    enabled: true
+    prefix: _
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  # Sort properties alphabetically
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    disabled_properties: []
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase
+
+  Shorthand:
+    enabled: true
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: false
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space
+
+  SpaceAfterComment:
+    enabled: true
+    style: one_space
+    allow_empty_comments: true
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 1
+
+  StringQuotes:
+    enabled: true
+    style: double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: true
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: true
+    properties:
+      - font
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false


### PR DESCRIPTION
See https://core.trac.wordpress.org/attachment/ticket/26905/26905.diff - our version is a little stricter on nesting, but otherwise matches.

This preserves the old rules for CodeClimate via `.sass-lint-r-1.x.yml `.

Question on naming: do we want to rename the main linter file to something like `.sass-lint-r-2.x.yml` so down the line when we update the standards, we don't need to go back to a bunch of repos to update to the "old" standards like we will with the 1.0 file?