### PR TITLE
Release/2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-# 2.0
+# 2.0.1
+
+- Convert the `.scss-lint-r-1.x.yml` configuration file to use the proper
+ `scss-lint` format. 
+
+# 2.0.0
 
 - This is the first versioned release of our coding standards. Let's start at
  2.0!


### PR DESCRIPTION
Included in this release:

- Convert the `.scss-lint-r-1.x.yml` to `scss-lint` format instead of `sass-lint` format.