### PR TITLE
Introduce stylelint configuration file

### DIFF
--- a/code-climate-rule-sets/.stylelintrc
+++ b/code-climate-rule-sets/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-wordpress"
+}

--- a/code-climate-rule-sets/.stylelintrc
+++ b/code-climate-rule-sets/.stylelintrc
@@ -1,3 +1,33 @@
 {
-  "extends": "stylelint-config-wordpress"
+	"extends": "stylelint-config-wordpress",
+	"rules": {
+		"max-nesting-depth": [ "3", {
+			ignore: [ "blockless-at-rules" ]
+		} ],
+		"no-descending-specificity": "true",
+		"no-duplicate-selectors": "true",
+		"no-invalid-double-slash-comments": "false",
+		"function-blacklist": [
+			"rotate",
+			"scale",
+			"translate",
+			"rgba",
+			"linear-gradient"
+		],
+		"function-url-scheme-blacklist": [
+			"ftp",
+			"/^http/",
+			"/cms-devl/",
+			"/test/",
+			"/wp-content/",
+			"/files/",
+		],
+		"declaration-no-important": "true",
+		"declaration-block-single-line-max-declarations": "1",
+		"selector-no-qualifying-type": [ "true", {
+			ignore: "attribute"
+		} ],
+		"selector-pseudo-class-blacklist": "focus",
+		"comment-word-blacklist": "/^TODO:/",
+	}
 }


### PR DESCRIPTION
From [Responsi #234](https://github.com/bu-ist/responsive-framework/issues/234):

> There is an officially maintained repository with WordPress coding standards for stylelint now. stylelint is powerful because it utilizes PostCSS, which means it can lint CSS and SASS files in the same engine.
> 
> The WordPress-Coding-Standards/stylelint-config-wordpress package allows for simple overrides using a configuration file.

This pull introduces the configuration file to our coding standards repo so it can be fetched in the `prepare` step of any repository, and be updated in one place for all repos.