### PR TITLE
Create PHPCS ruleset files

### DIFF
--- a/code-climate-rule-sets/phpcs-plugins.xml
+++ b/code-climate-rule-sets/phpcs-plugins.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset name="Plugins Custom Ruleset">
+	<description>Custom sniff configuration specifically for WordPress plugins.</description>
+
+	<rule ref="WordPress" />
+
+	<!-- By default, the WordPress standard excludes checks for create_function() because it still exists in core. -->
+	<!-- Until this exclusion is removed from the standard, we want to override that by providing our own properties. -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#existing-exclusions -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<!-- From "VIP": The obfuscation group is excluded as there are plenty of legitimate uses for the base64 functions. -->
+		<properties>
+			<property name="exclude" value="obfuscation"/>
+		</properties>
+	</rule>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="Responsive Framework Custom Ruleset">
+	<description>Custom sniff configuration specifically for Responsive Framework Child Themes.</description>
+
+	<rule ref="WordPress" />
+
+	<!-- Defining `is_theme` as true prevents post type and taxonomy templates with underscores from throwing errors. -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#themes-allow-filename-exceptions -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="is_theme" value="true" />
+		</properties>
+	</rule>
+
+	<!-- By default, the WordPress standard excludes checks for create_function() because it still exists in core. -->
+	<!-- Until this exclusion is removed from the standard, we want to override that by providing our own properties. -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#existing-exclusions -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<!-- From "VIP": The obfuscation group is excluded as there are plenty of legitimate uses for the base64 functions. -->
+		<properties>
+			<property name="exclude" value="obfuscation"/>
+		</properties>
+	</rule>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
There are a few things in the default WordPress `PHP_CodeSniffer` ruleset that we want to tweak.

In themes, templates for post types and taxonomies are `archive-post_type.php`. Post type names usually include underscores (`_`). This causes a warning to be generated because the standard encourages hyphens (`-`) instead of underscores.

For themes, we [want to override this](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#themes-allow-filename-exceptions).

The `create_function()` function occurrences are also excluded from being flagged. This is because there are still a few occurrences of the function in core. We want to check for this function as it was deprecated in PHP `7.2`, and has many flaws (insecurity is one).

By establishing two custom rulesets for `PHPCS` in this repository, it allows them to be fetched in the `prepare` step in Code Climate and gives us one central file to update when changes need to be pushed out to our code standard rules for all themes.