### PR TITLE
Inform PHPCS rule of properly escaped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+- Inform the `WordPress.XSS.EscapeOutput` rule of BU functions that properly escape output.
+
 ## 2.0.3
 
 - Introduce default custom `PHPCS` rulesets for plugins and themes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.4
 
-- Inform the `WordPress.XSS.EscapeOutput` rule of BU functions that properly escape output.
+- Inform the `WordPress.XSS.EscapeOutput` rule of BU functions that properly escape output. `bu_sanitize_banner_subtitle()` and
+`bu_banners_get_image()` were added.
 
 ## 2.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 # Changelog
 
-# 2.0.3
+## 2.0.3
 
 - Introduce default custom `PHPCS` rulesets for plugins and themes.
 
-# 2.0.2
+## 2.0.2
 
 - Prevent SASSdoc comments from triggering issues.
 
-# 2.0.1
+## 2.0.1
 
 - Convert the `.scss-lint-r-1.x.yml` configuration file to use the proper
  `scss-lint` format. 
 
-# 2.0.0
+## 2.0.0
 
 - This is the first versioned release of our coding standards. Let's start at
  2.0!

--- a/code-climate-rule-sets/phpcs-plugins.xml
+++ b/code-climate-rule-sets/phpcs-plugins.xml
@@ -14,6 +14,15 @@
 		</properties>
 	</rule>
 
+	<!-- All output should be properly escaped to avoid potential cross site scripting (XSS) attacks. -->
+	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
+	<!-- All functions that properly escape output can be added here. -->
+	<rule ref="WordPress.XSS.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />
+		</properties>
+	</rule>
+
 	<!-- Show sniff codes in all reports -->
 	<arg value="s"/>
 

--- a/code-climate-rule-sets/phpcs-plugins.xml
+++ b/code-climate-rule-sets/phpcs-plugins.xml
@@ -17,6 +17,7 @@
 	<!-- All output should be properly escaped to avoid potential cross site scripting (XSS) attacks. -->
 	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
 	<!-- All functions that properly escape output can be added here. -->
+	<!-- Functions added to this list must have unit tests demonstrating that harmful code is properly stripped out or sanitized. -->
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -29,6 +29,7 @@
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />
+			<property name="customAutoEscapedFunctions" value="bu_sanitize_banner_subtitle" type="array" />
 		</properties>
 	</rule>
 

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -25,6 +25,7 @@
 	<!-- All output should be properly escaped to avoid potential cross site scripting (XSS) attacks. -->
 	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
 	<!-- All functions that properly escape output can be added here. -->
+	<!-- Functions added to this list must have unit tests demonstrating that harmful code is properly stripped out or sanitized. -->
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -22,6 +22,15 @@
 		</properties>
 	</rule>
 
+	<!-- All output should be properly escaped to avoid potential cross site scripting (XSS) attacks. -->
+	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
+	<!-- All functions that properly escape output can be added here. -->
+	<rule ref="WordPress.XSS.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />
+		</properties>
+	</rule>
+
 	<!-- Show sniff codes in all reports -->
 	<arg value="s"/>
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -249,7 +249,7 @@ The most commonly used translation function is `__()`.
 
 `$translated_text = __( 'A string to translate', 'bu-bp' );`
 
-Another basic one is `_e()`. This is exactly the same as `__()`, with the exception of the result being printed to the screen.
+Another basic option is `_e()`. This functions the same as `__()`, with the exception of the result being printed to the screen.
 
 ```
 // These two examples are exactly the same.
@@ -263,6 +263,8 @@ Other functions exist performing additional formatting to translated content. A 
 
 * [`esc_attr_e()`](https://codex.wordpress.org/Function_Reference/esc_attr_e) and [`esc_attr__()`](https://codex.wordpress.org/Function_Reference/esc_attr__): Translates a string and escapes it for use in an attribute.
 * [`esc_html_e()`](https://codex.wordpress.org/Function_Reference/esc_html_e) and [`esc_html__()`](https://codex.wordpress.org/Function_Reference/esc_html__): Translates a string and escapes any HTML within it.
+
+It is best to use the above examples as sanitization is also required for standards.
 
 ###Variables
 


### PR DESCRIPTION
The `WordPress.XSS.EscapeOutput` correctly identifies all output run through WordPress core functions as correctly escaped to prevent Cross-Site Scripting (XSS) and other attacks.

There are, however, many functions in our environment that correctly escape output and should not throw warnings about the potential for XSS attacks. By adding a list to the PHPCS custom rulesets, these can be passed to PHPCS to avoid incorrect false positives.

There does need to be a couple of guidelines and rules for adding functions to the ruleset because these PHPCS rulesets are used by default for all plugins and themes in Code Climate.

1. Because this change will prevent potential warnings asking for output to be escaped, all functions added to this list **must** have proper unit tests demonstrating that harmful code is properly escaped or removed.
2. Only functions that will be used outside of a repository should be added. Example: A theme has a custom function that properly escapes output, but that function is only used in that theme. These instances should either be flagged as acceptable using the [inline comment method of whitelisting](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors). Copying this default PHPCS ruleset into the plugin or theme repo should be avoided unless absolutely necessary because it will prevent that repository from receiving future additions and improvements to this default ruleset without manually copying them over.

A good example of a function that should be added to this list (and the one being added here) is `bu_banners_get_image()`.  This function retrieves a `<picture>` element containing the correct `<source>` and `<img />` tags to display a page's banner. This function is used within the plugin, but themes have the ability to override the templates used to display banners. If a theme uses `bu_banners_get_image()`, they should not be told they need to escape the results of that function when outputting because the function itself handles that, and the result of the function can be considered trusted output.

Note: as of writing this, the `bu_banners_get_image()` function is not yet merged into the BU Banners plugin, but will be shortly after this PR is merged (See [BU Banners #70](https://github.com/bu-ist/bu-banners/pull/70/)).
  