### PR TITLE
Tone down the rules a bit

### DIFF
--- a/code-climate-rule-sets/.scss-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-2.x.yml
@@ -179,7 +179,7 @@ linters:
 
   StringQuotes:
     enabled: true
-    style: double_quotes
+    style: single_quotes
 
   TrailingSemicolon:
     enabled: true

--- a/code-climate-rule-sets/.scss-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-2.x.yml
@@ -197,7 +197,7 @@ linters:
     enabled: true
 
   UnnecessaryParentReference:
-    enabled: true
+    enabled: false
 
   UrlFormat:
     enabled: true


### PR DESCRIPTION
- Turn off the rule that enforces removing "unnecessary" `&` references - these references help clarify the difference between rules that target children and siblings
- Maybe adjust the naming convention filter to exclude flagging any classes that begin with `wp_` and `gform_`