### PR TITLE
Add patterns to exclude common selectors from things we can't control…

### DIFF
--- a/code-climate-rule-sets/.scss-lint-r-1.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-1.x.yml
@@ -122,8 +122,8 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: (^[a-z]|^wp\_|^gform\_)[a-z\-0-9]*$
-    convention_explanation: 'Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning wp_ and gform_ (and only for the prefix itself; no subsequent underscores may be used). Additonally, overriding the col- classes is prohibited.'
+    convention: (^[a-z][a-zA\--Z0-9]*$)
+    convention_explanation: 'Classes may not use UPPERCASE or underscores. Additonally, overriding the col- classes is prohibited.'
 
   Shorthand:
     enabled: true

--- a/code-climate-rule-sets/.scss-lint-r-1.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-1.x.yml
@@ -122,8 +122,8 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: (^[a-z][a-zA\--Z0-9]*$)
-    convention_explanation: 'Classes may not use UPPERCASE or underscores. Additonally, overriding the col- classes is prohibited.'
+    convention: (^[a-z]|^wp\_|^gform\_)[a-z\-0-9]*$
+    convention_explanation: 'Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning wp_ and gform_ (and only for the prefix itself; no subsequent underscores may be used). Additonally, overriding the col- classes is prohibited.'
 
   Shorthand:
     enabled: true

--- a/code-climate-rule-sets/.scss-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-2.x.yml
@@ -90,8 +90,7 @@ linters:
   NameFormat:
     enabled: true
     allow_leading_underscore: true
-    convention: (^[a-z][a-zA\--Z0-9]*$)
-    convention_explanation: 'Classes may not use UPPERCASE or underscores.'
+    convention: hyphenated_lowercase
 
   NestingDepth:
     enabled: true
@@ -134,7 +133,8 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
+    convention: (^[a-z]|^wp\_|^gform\_)[a-z\-0-9]*$
+    convention_explanation: 'Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning wp_ and gform_ (and only for the prefix itself; no subsequent underscores may be used).'
 
   Shorthand:
     enabled: true

--- a/code-climate-rule-sets/.scss-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-2.x.yml
@@ -90,7 +90,8 @@ linters:
   NameFormat:
     enabled: true
     allow_leading_underscore: true
-    convention: hyphenated_lowercase
+    convention: (^[a-z][a-zA\--Z0-9]*$)
+    convention_explanation: 'Classes may not use UPPERCASE or underscores.'
 
   NestingDepth:
     enabled: true


### PR DESCRIPTION
Changes to Sass class checks: Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning wp_ and gform_ (and only for the prefix itself; no subsequent underscores may be used). Additionally, overriding the col- classes is prohibited.