### PR TITLE
Allow the bu_ namespace for BU Front End Library

### DIFF
--- a/code-climate-rule-sets/.scss-lint-r-2.x.yml
+++ b/code-climate-rule-sets/.scss-lint-r-2.x.yml
@@ -133,8 +133,8 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: (^[a-z]|^wp\_|^gform\_)[a-z\-0-9]*$
-    convention_explanation: 'Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning wp_ and gform_ (and only for the prefix itself; no subsequent underscores may be used).'
+    convention: (^[a-z]|^wp\_|^gform\_|^bu\_)[a-z\-0-9]*$
+    convention_explanation: 'Classes may not use UPPERCASE. Underscores are only allowed only for classes beginning with wp_, gform_, or bu_ (and only for the prefix itself; no subsequent underscores may be used).'
 
   Shorthand:
     enabled: true


### PR DESCRIPTION
Classes such as `.bu_collapsible` shouldn't trigger this error because they are out of our control.