### PR TITLE
Exclude “WordPress-VIP” subset for code climate

### DIFF
--- a/code-climate-rule-sets/phpcs-plugins.xml
+++ b/code-climate-rule-sets/phpcs-plugins.xml
@@ -2,7 +2,10 @@
 <ruleset name="Plugins Custom Ruleset">
 	<description>Custom sniff configuration specifically for WordPress plugins.</description>
 
-	<rule ref="WordPress" />
+	<!-- Until Code Climate updates WPCS to 1.0.0, only include the subsets we want (exclude WordPress VIP) -->
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra"/>
 
 	<!-- By default, the WordPress standard excludes checks for create_function() because it still exists in core. -->
 	<!-- Until this exclusion is removed from the standard, we want to override that by providing our own properties. -->

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -2,7 +2,10 @@
 <ruleset name="Responsive Framework Custom Ruleset">
 	<description>Custom sniff configuration specifically for Responsive Framework Child Themes.</description>
 
-	<rule ref="WordPress" />
+	<!-- Until Code Climate updates WPCS to 1.0.0, only include the subsets we want (exclude WordPress VIP) -->
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra"/>
 
 	<!-- Defining `is_theme` as true prevents post type and taxonomy templates with underscores from throwing errors. -->
 	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#themes-allow-filename-exceptions -->


### PR DESCRIPTION
Code Climate is currently using WPCS 0.14.0 at this time. 

There is an open PR to update to WPCS 0.14.1 https://github.com/codeclimate/codeclimate-phpcodesniffer/pull/71/files. 

However, both of these versions of WPCS have the WordPress ruleset that includes the “WordPress-VIP” subset. This means that developers will still be prompted by Code Climate to resolve WordPress VIP platform-specific issues, such as [not using the 'rand' in WP_Query and to use 'vip_get_random_posts' instead ](https://github.com/bu-ist/r-admissions/pull/164#issuecomment-415454275) or to use ['wpcom_vip_get_adjacent_post' instead of 'get_previous_post_link' for caching reasons](https://codeclimate.com/repos/582231969f3c3f007e003961/inc/template-tags.php/source#issue-c344d58476198cb69d41cef6b7b86133)

I propose that we adjust our Code Climate phpcs rulesets to exclude the WordPress-VIP. This PR replaces the “WordPress” ruleset with just its subsets (minus “WordPress-VIP”).

Once Code Climate updates WPCS to 1.0.0 (eventually), we can update to use the "WordPress" ruleset as a whole again because they [officially deprecated VIP](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.0.0) and its no longer an included subset, and is [specifically ignored in 1.0.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/1.0.0/WordPress/ruleset.xml#L7-L12)