### PR TITLE
Rename deprecated rules

### DIFF
--- a/code-climate-rule-sets/phpcs-plugins.xml
+++ b/code-climate-rule-sets/phpcs-plugins.xml
@@ -8,7 +8,7 @@
 	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
 	<!-- All functions that properly escape output can be added here. -->
 	<!-- Functions added to this list must have unit tests demonstrating that harmful code is properly stripped out or sanitized. -->
-	<rule ref="WordPress.XSS.EscapeOutput">
+	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />
 		</properties>

--- a/code-climate-rule-sets/phpcs-themes.xml
+++ b/code-climate-rule-sets/phpcs-themes.xml
@@ -16,7 +16,7 @@
 	<!-- The WPCS accounts for the WordPress Core functions that properly escape output, but not functions in our environment. -->
 	<!-- All functions that properly escape output can be added here. -->
 	<!-- Functions added to this list must have unit tests demonstrating that harmful code is properly stripped out or sanitized. -->
-	<rule ref="WordPress.XSS.EscapeOutput">
+	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="bu_banners_get_image" type="array" />
 			<property name="customAutoEscapedFunctions" value="bu_sanitize_banner_subtitle" type="array" />


### PR DESCRIPTION
In release [1.0.0 of the Word Press Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.0.0) several rules were renamed. 

These are now causing errors in our Custom Code Climate ruleset and need to be updated. See an example on `r-thurman` https://codeclimate.com/repos/5ae3699f59192002a4009642/pull/6