### PR TITLE
Various additions to phpbin standards

### DIFF
--- a/phpbin/README.md
+++ b/phpbin/README.md
@@ -34,6 +34,13 @@ Because there are other, well maintained best practice manuals available, this g
 
 This repo also comes with a `composer-phpbin.json` file. If the app you're working on does not use composer, add this file as `composer.json` into the app and run `composer install` to install PHPCodeSniffer, WordPress coding standards and PHP 5.3 Compatability sniffs.
 
+If your project is already using `composer`, run these commands to install the dependencies mentioned above:
+```
+composer require --dev "dealerdirect/phpcodesniffer-composer-installer=*"
+composer require --dev "phpcompatibility/php-compatibility=*"
+composer require --dev "wp-coding-standards/wpcs=*"
+```
+
 To sniff all PHP files:
 
 ```bash

--- a/phpbin/phpcs-snake.xml
+++ b/phpbin/phpcs-snake.xml
@@ -8,6 +8,13 @@
 	<config name="testVersion" value="5.3-"/>
 
 	<rule ref="WordPress">
+		<!-- Disable sniff complaining about file comment -->
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+
+		<!-- Disable sniffs complaining about filenames -->
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
 		<!-- Disable WP nonce sniffs -->
 		<exclude name="WordPress.Security.NonceVerification.NoNonceVerification" />
 
@@ -20,4 +27,8 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- When running phpcs on Travis, the directory path contains "build".
+	     If you use "*/build/*" as exclude-pattern, it results in having
+	     no files for sniffing. Thus, try to be as specific as possible. -->
+	<exclude-pattern>*/build/logs*</exclude-pattern>
 </ruleset>

--- a/phpbin/phpcs.xml
+++ b/phpbin/phpcs.xml
@@ -8,6 +8,13 @@
 	<config name="testVersion" value="5.3-"/>
 
 	<rule ref="WordPress">
+			<!-- Disable sniff complaining about file comment -->
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+
+		<!-- Disable sniffs complaining about filenames -->
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
 		<!-- Disable sniffs complaining about snake_case -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.StringNotSnakeCase" />
@@ -32,4 +39,8 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- When running phpcs on Travis, the directory path contains "build".
+	     If you use "*/build/*" as exclude-pattern, it results in having
+	     no files for sniffing. Thus, try to be as specific as possible. -->
+	<exclude-pattern>*/build/logs*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Changes the following:

- Removes some sniffs that aren't useful for PSR4-compatible code
- Explains how to better exclude "build" directory (created by test coverage reported of `phpunit`) from sniffing
- Suggests a way of adding composer dependencies for projects that already use composer.