### PR TITLE
Ignore additional WordPress phpcs rules

### DIFF
--- a/phpbin/phpcs.xml
+++ b/phpbin/phpcs.xml
@@ -21,6 +21,10 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase" />
 
 		<!-- Disable WP nonce sniffs -->
 		<exclude name="WordPress.Security.NonceVerification.NoNonceVerification" />
@@ -30,6 +34,8 @@
 
 		<!-- Disable all WP alt functions since we won't have WP alts in non-WP -->
 		<exclude name="WordPress.WP.AlternativeFunctions" />
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.MissingUnslash" />
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized" />
 	</rule>
 
 	<!-- Require methods and variables be in camelCase, PascalCase for classes -->


### PR DESCRIPTION
Adds two changes:
1. Ignore more of `WordPress.NamingConventions.ValidVariableName.*` rules that were added in latest versions of PHPCS
1. Ignore `WordPress.Security.ValidatedSanitizedInput.*` because we can't satisfy those rules without having `sanitize_*` or `wp_unslash` functions that are only available in WordPress.